### PR TITLE
[AE-476]: Added two properties in Address Model

### DIFF
--- a/Common/Address.cs
+++ b/Common/Address.cs
@@ -26,8 +26,14 @@ namespace Ivvy.Common
         [JsonProperty("stateCode")]
         public string StateCode { get; set; }
 
+        [JsonProperty("stateName")]
+        public string StateName { get; set; }
+
         [JsonProperty("countryCode")]
         public string CountryCode { get; set; }
+
+        [JsonProperty("countryName")]
+        public string CountryName { get; set; }
 
         [JsonProperty("postalCode")]
         public string PostalCode { get; set; }


### PR DESCRIPTION
In Xero, we are using the countryName and stateName fields and Ivvy API is also returning those fields. So, we have added those two properties in Ivvy SDK.