### PR TITLE
Custom Field Data type change

### DIFF
--- a/Account/CustomField.cs
+++ b/Account/CustomField.cs
@@ -1,5 +1,6 @@
 ﻿using Ivvy.Json;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Ivvy.Account
 {
@@ -34,7 +35,7 @@ namespace Ivvy.Account
         public int SortOrder { get; set; }
 
         [JsonProperty("selectValues")]
-        public object SelectValues { get; set; }
+        public Dictionary<string, string> SelectValues { get; set; }
 
         [JsonProperty("fileTypes")]
         public string[] FileTypes { get; set; }


### PR DESCRIPTION
Changed the data type of **SelectValues** property to **Dictionary<string, string>** from **object** as part of bug AE-545..