### PR TITLE
Added a setting that forces serializing the accommodation's cutoff date.

### DIFF
--- a/src/Venue/Bookings/Accommodation.cs
+++ b/src/Venue/Bookings/Accommodation.cs
@@ -69,7 +69,7 @@ namespace Ivvy.API.Venue.Bookings
             get; set;
         }
 
-        [JsonProperty("cutOffDate")]
+        [JsonProperty("cutOffDate", NullValueHandling = NullValueHandling.Include)]
         public string CutOffDate
         {
             get; set;


### PR DESCRIPTION
Added a setting that forces serializing the cutoff date, whether there is a value or not.