### PR TITLE
Item ref type made an integer in order to handle all ref types, not o…

### DIFF
--- a/src/Invoice/Item.cs
+++ b/src/Invoice/Item.cs
@@ -26,7 +26,7 @@ namespace Ivvy.API.Invoice
         }
 
         [JsonProperty("refType")]
-        public RefTypes RefType
+        public int RefType
         {
             get; set;
         }


### PR DESCRIPTION
…nly the default ones.