### PR TITLE
Payment method's data type changed to System.Int32 in order to handle…

### DIFF
--- a/src/Invoice/AddPayment.cs
+++ b/src/Invoice/AddPayment.cs
@@ -27,7 +27,13 @@ namespace Ivvy.API.Invoice
         }
 
         [JsonProperty("paymentMethod")]
-        public InvoicePayment.PaymentMethods PaymentMethod
+        public int PaymentMethod
+        {
+            get; set;
+        }
+
+        [JsonProperty("customPaymentMethodId")]
+        public int? CustomPaymentMethodId
         {
             get; set;
         }

--- a/src/Invoice/InvoicePayment.cs
+++ b/src/Invoice/InvoicePayment.cs
@@ -68,7 +68,7 @@ namespace Ivvy.API.Invoice
         }
 
         [JsonProperty("paymentMethod")]
-        public PaymentMethods PaymentMethod
+        public int PaymentMethod
         {
             get; set;
         }


### PR DESCRIPTION
… all payment methods, not only the default ones.