### PR TITLE
The number of payable rooms made optional.

### DIFF
--- a/src/Venue/Bookings/AccommodationDayRate.cs
+++ b/src/Venue/Bookings/AccommodationDayRate.cs
@@ -27,7 +27,7 @@ namespace Ivvy.API.Venue.Bookings
         }
 
         [JsonProperty("numPayableByGuest")]
-        public int NumPayableByGuest
+        public int? NumPayableByGuest
         {
             get; set;
         }


### PR DESCRIPTION
The number of payable rooms made optional in order to keep it the same and not set it to its default value '0', when no data is available for it.