### PR TITLE
Added owner to the 'opportunity' data model.

### DIFF
--- a/src/Crm/Opportunity.cs
+++ b/src/Crm/Opportunity.cs
@@ -85,5 +85,11 @@ namespace Ivvy.API.Crm
         {
             get; set;
         }
+
+        [JsonProperty("ownerUser")]
+        public OpportunityOwner OwnerUser
+        {
+            get; set;
+        }
     }
 }

--- a/src/Crm/OpportunityOwner.cs
+++ b/src/Crm/OpportunityOwner.cs
@@ -1,0 +1,37 @@
+using Newtonsoft.Json;
+
+namespace Ivvy.API.Crm
+{
+    public class OpportunityOwner
+    {
+        [JsonProperty("id")]
+        public int Id
+        {
+            get; set;
+        }
+
+        [JsonProperty("firstName")]
+        public string FirstName
+        {
+            get; set;
+        }
+
+        [JsonProperty("lastName")]
+        public string LastName
+        {
+            get; set;
+        }
+
+        [JsonProperty("email")]
+        public string Email
+        {
+            get; set;
+        }
+
+        [JsonProperty("phone")]
+        public string Phone
+        {
+            get; set;
+        }
+    }
+}


### PR DESCRIPTION
Used a separate class named 'OpportunityOwner' instead of 'Ivvy.API.Account.User' because the data provided by the API (getOpportunityList) for the user is only "id", "firstName", "lastName", "email" and "phone", the remaining data members will be deserialized with their default values which may mislead the developer.